### PR TITLE
Fix State

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -156,7 +156,7 @@ class CustomPersonCard extends LitElement {
                   >${people[person].state === 'home'
                   || people[person].state === 'not_home'
       ? translations[
-        `component.person.state._.${people[person].state}`
+        `component.component.person.entity_component._.state.${people[person].state}`
       ]
       : people[person].state}
                 </span>


### PR DESCRIPTION
Using HomeAssistant `2023.4`  - when running chrome dev-tools:

```
translationsl["component.person.state._.home"]
>undefined
```

but 

```
translations["component.person.entity_component._.state.home"]
>'Home'
```

See this:
https://developers.home-assistant.io/blog/2023/03/27/entity_name_translations/

Should fix #35 